### PR TITLE
Add gateway route

### DIFF
--- a/lib/blockchain_api_web/controllers/gateway_controller.ex
+++ b/lib/blockchain_api_web/controllers/gateway_controller.ex
@@ -15,8 +15,8 @@ defmodule BlockchainAPIWeb.GatewayController do
     render(conn, "index.json", add_gateway_transactions: add_gateway_transactions)
   end
 
-  def show(conn, %{"id" => id}) do
-    gateway = Explorer.get_gateway!(id)
+  def show(conn, %{"hash" => hash}) do
+    gateway = Explorer.get_gateway!(hash)
     render(conn, "show.json", gateway: gateway)
   end
 end

--- a/lib/blockchain_api_web/router.ex
+++ b/lib/blockchain_api_web/router.ex
@@ -18,6 +18,7 @@ defmodule BlockchainAPIWeb.Router do
       resources "/transactions", AccountTransactionController, only: [:index], param: "account_address"
     end
 
+    resources "/gateways", GatewayController, only: [:index, :show], param: "gateway_hash"
 
     # resources "/coinbase_transactions", CoinbaseController, except: [:new, :edit, :delete, :update]
     # resources "/payment_transactions", PaymentController, except: [:new, :edit, :delete, :update]


### PR DESCRIPTION
Adds the following routes:

```
gateway_path  GET  /api/gateways                                BlockchainAPIWeb.GatewayController :index
gateway_path  GET  /api/gateways/:gateway_hash                  BlockchainAPIWeb.GatewayController :show
```

Note: This is untested but it _should_ work. We can test it when we get add_gw txns working as a first pass.

