### PR TITLE
Remove gateway reference from pending_location

### DIFF
--- a/priv/repo/migrations/20190220221350_add_pending_location_table.exs
+++ b/priv/repo/migrations/20190220221350_add_pending_location_table.exs
@@ -8,9 +8,9 @@ defmodule BlockchainAPI.Repo.Migrations.AddPendingLocationTable do
       add :location, :string, null: false
       add :fee, :bigint, null: false
       add :nonce, :bigint, null: false
+      add :gateway, :string, null: false
 
       add :owner, references(:accounts, on_delete: :nothing, column: :address, type: :string), null: false
-      add :gateway, references(:gateway_transactions, on_delete: :nothing, column: :gateway, type: :string), null: false
 
       timestamps()
     end


### PR DESCRIPTION
It is possible that an `add_gateway` and `assert_loc` are done together and may appear in the same block, for example during onboarding. I had a strict constraint in the `pending_locations` table to check whether the gateway had already been added to the ledger but I suppose that's a false assumption to make.

NOTE: We should perhaps test this change before landing it. Basically performing an onboarding from the app would verify that this change is worthwhile. It would also require running a `reset-db` to have new migrations.