### PR TITLE
Remove get_acount_detail function

### DIFF
--- a/lib/blockchain_api/explorer/explorer.ex
+++ b/lib/blockchain_api/explorer/explorer.ex
@@ -209,33 +209,6 @@ defmodule BlockchainAPI.Explorer do
     |> Repo.one!
   end
 
-  def get_account_detail(address) do
-    query = from(
-      a in Account,
-      where: a.address == ^address,
-      left_join: pt in PaymentTransaction,
-      on: a.address == pt.payer,
-      left_join: lt in LocationTransaction,
-      on: a.address == lt.owner,
-      order_by: [desc: pt.id, desc: lt.id],
-      select: %{
-        balance: a.balance,
-        address: a.address,
-        name: a.name,
-        fee: a.fee,
-        payment: %{
-          nonce: pt.nonce
-        },
-        location: %{
-          nonce: lt.nonce
-        }
-      },
-      limit: 1
-    )
-
-    query |> Repo.one
-  end
-
   def update_account(account, attrs \\ %{}) do
     account.address
     |> get_account!()

--- a/lib/blockchain_api_web/controllers/account_controller.ex
+++ b/lib/blockchain_api_web/controllers/account_controller.ex
@@ -20,7 +20,7 @@ defmodule BlockchainAPIWeb.AccountController do
   end
 
   def show(conn, %{"address" => address}) do
-    render(conn, "show.json", account: Explorer.get_account_detail(address))
+    render(conn, "show.json", account: Explorer.get_account!(address))
   end
 
 end


### PR DESCRIPTION
So this was a bad change to make in the first place since, it's totally possible for an account owner to have multiple gateways which assert their mutually exclusive locations with independent nonces. Before this change, account_detail would give you _some_ nonce which may or may not have corresponded to the correct gateway.

Rather than that, `get_account!` gives you an account when you hit `/api/accounts/<addr>` and the top-level nonce there corresponds to the payment nonce for that account.

To get the location nonce, the ideal way would be to hit `/api/accounts/<addr>/gateways` and if there is no data there, location nonce=1 otherwise read through the data and figure out the corresponding gateway's nonce.