### PR TITLE
Default return for non-existent account

### DIFF
--- a/lib/blockchain_api_web/controllers/account_controller.ex
+++ b/lib/blockchain_api_web/controllers/account_controller.ex
@@ -27,6 +27,8 @@ defmodule BlockchainAPIWeb.AccountController do
       account_with_balance = Map.merge(account, %{history: account_balance_history})
       render(conn, "show.json", account: account_with_balance)
     rescue
+      # NOTE: This should probably be somewhere else and feels like a hack
+      # This account does not exist in the database, hence we return some default values
       _error in Ecto.NoResultsError ->
         {:ok, fee} = Watcher.chain()
                      |> :blockchain.ledger()
@@ -36,7 +38,11 @@ defmodule BlockchainAPIWeb.AccountController do
             address: address,
             fee: fee,
             balance: 0,
-            history: [],
+            history: %{
+              day: [],
+              week: [],
+              month: []
+            },
             id: nil,
             name: nil,
             nonce: 0


### PR DESCRIPTION
@allenan I'm open to suggestion on how to do this better, but it "works" for the use case we discussed offline.

Returning response:
`{"data":{"address":"13kfLuCF513xgLVEUGErYULST28QKEyfqQNta5F6T3PkRtyNVCz","balance":0,"fee":7,"history":[],"id":null,"name":null,"nonce":0}}`