### PR TITLE
Aggregate past 24 hr challenges

### DIFF
--- a/lib/blockchain_api/query/account_balance.ex
+++ b/lib/blockchain_api/query/account_balance.ex
@@ -3,7 +3,7 @@ defmodule BlockchainAPI.Query.AccountBalance do
   import Ecto.Query, warn: false
   use Timex
 
-  alias BlockchainAPI.{Repo, Schema.AccountBalance}
+  alias BlockchainAPI.{Repo, Util, Schema.AccountBalance}
 
   def get_latest!(address) do
     AccountBalance
@@ -32,17 +32,17 @@ defmodule BlockchainAPI.Query.AccountBalance do
   #==================================================================
   defp get_account_balances_daily(address) do
     start = Timex.now() |> Timex.shift(hours: -24) |> Timex.to_unix()
-    query_account_balance(address, start, current_time())
+    query_account_balance(address, start, Util.current_time())
   end
 
   defp get_account_balances_weekly(address) do
     start = Timex.now() |> Timex.shift(days: -7) |> Timex.to_unix()
-    query_account_balance(address, start, current_time())
+    query_account_balance(address, start, Util.current_time())
   end
 
   defp get_account_balances_monthly(address) do
     start = Timex.now() |> Timex.shift(days: -30) |> Timex.to_unix()
-    query_account_balance(address, start, current_time())
+    query_account_balance(address, start, Util.current_time())
   end
 
   defp query_account_balance(address, start, finish) do
@@ -59,10 +59,6 @@ defmodule BlockchainAPI.Query.AccountBalance do
     )
 
     query |> Repo.all
-  end
-
-  defp current_time() do
-    Timex.now() |> Timex.to_unix()
   end
 
   defp sample_daily_account_balance(address) do
@@ -110,9 +106,9 @@ defmodule BlockchainAPI.Query.AccountBalance do
 
   defp interval_filter(address, range, fun, shift) do
     hr_shift = 3600*shift
-    offset= rem(current_time(), hr_shift)
-    now = div(current_time() - offset, hr_shift)
-    then = div(current_time() - (offset + (hr_shift * length(Enum.to_list(range)))), hr_shift)
+    offset= rem(Util.current_time(), hr_shift)
+    now = div(Util.current_time() - offset, hr_shift)
+    then = div(Util.current_time() - (offset + (hr_shift * length(Enum.to_list(range)))), hr_shift)
 
     map = Range.new(then, now)
           |> Enum.map(fn key -> {key, []} end)

--- a/lib/blockchain_api/query/poc_receipts_transaction.ex
+++ b/lib/blockchain_api/query/poc_receipts_transaction.ex
@@ -54,14 +54,16 @@ defmodule BlockchainAPI.Query.POCReceiptsTransaction do
     |> encode()
   end
 
+  def challenges_twenty_four_hrs(_params) do
+    path_query()
+    |> receipt_query_twenty_four_hrs()
+    |> Repo.all()
+    |> encode_twenty_four_hrs()
+  end
+
   def get!(hash) do
     POCReceiptsTransaction
     |> where([poc_receipts_txn], poc_receipts_txn.hash == ^hash)
-    |> Repo.one!
-  end
-
-  def completed(_params) do
-    from(poc_receipts_txn in POCReceiptsTransaction, select: count(poc_receipts_txn.id))
     |> Repo.one!
   end
 
@@ -69,6 +71,25 @@ defmodule BlockchainAPI.Query.POCReceiptsTransaction do
     %POCReceiptsTransaction{}
     |> POCReceiptsTransaction.changeset(attrs)
     |> Repo.insert()
+  end
+
+  defp encode_twenty_four_hrs([]), do: []
+  defp encode_twenty_four_hrs(entries) do
+    issued = length(entries)
+    successful = entries
+                 |> Enum.map(&is_successful/1)
+                 |> Enum.count(fn x -> x == true end)
+    failed = issued - successful
+    %{issued: issued, successful: successful, failed: failed}
+  end
+
+  defp is_successful(%{challenge: entry}) do
+    path_elements = entry.poc_path_elements
+                    |> encode_path_elements()
+                    #NOTE: The path always seems to end up in reverse order
+                    |> Enum.reverse()
+
+    Enum.all?(path_elements, fn(elem) -> elem.result == "success" end)
   end
 
   defp encode([]), do: []
@@ -229,5 +250,24 @@ defmodule BlockchainAPI.Query.POCReceiptsTransaction do
     query
     |> where([poc_rx], poc_rx.id < ^before)
     |> limit(^limit)
+  end
+
+  defp receipt_query_twenty_four_hrs(path_query) do
+    start = Timex.now() |> Timex.shift(hours: -24) |> Timex.to_unix()
+    finish = Util.current_time()
+    from(
+      rx in POCReceiptsTransaction,
+      preload: [poc_path_elements: ^path_query],
+      left_join: t in Transaction,
+      on: rx.hash == t.hash,
+      left_join: b in Block,
+      on: t.block_height == b.height,
+      where: b.time >= ^start,
+      where: b.time <= ^finish,
+      left_join: h in Hotspot,
+      on: rx.challenger == h.address,
+      order_by: [desc: rx.id],
+      select: %{challenge: rx, height: t.block_height, hotspot: h, block: b}
+    )
   end
 end

--- a/lib/blockchain_api/util.ex
+++ b/lib/blockchain_api/util.ex
@@ -1,4 +1,5 @@
 defmodule BlockchainAPI.Util do
+  use Timex
 
   alias BlockchainAPI.Schema.{
     PaymentTransaction,
@@ -128,4 +129,9 @@ defmodule BlockchainAPI.Util do
         :blockchain_ledger_entry_v1.nonce(entry)
     end
   end
+
+  def current_time() do
+    Timex.now() |> Timex.to_unix()
+  end
+
 end

--- a/lib/blockchain_api_web/controllers/challenge_controller.ex
+++ b/lib/blockchain_api_web/controllers/challenge_controller.ex
@@ -8,13 +8,15 @@ defmodule BlockchainAPIWeb.ChallengeController do
   def index(conn, params) do
     challenges = Query.POCReceiptsTransaction.challenges(params)
     ongoing = Query.POCRequestTransaction.ongoing(params)
-    completed = Query.POCReceiptsTransaction.completed(params)
+    aggregated = Query.POCReceiptsTransaction.challenges_twenty_four_hrs(params)
 
     render(conn,
       "index.json",
       challenges: challenges,
       total_ongoing: ongoing,
-      total_completed: completed
+      issued: aggregated.issued,
+      successful: aggregated.successful,
+      failed: aggregated.failed
     )
   end
 

--- a/lib/blockchain_api_web/views/challenge_view.ex
+++ b/lib/blockchain_api_web/views/challenge_view.ex
@@ -5,7 +5,9 @@ defmodule BlockchainAPIWeb.ChallengeView do
   def render("index.json", data) do
     %{
       totalOngoing: data.total_ongoing,
-      totalCompleted: data.total_completed,
+      issued: data.issued,
+      successful: data.successful,
+      failed: data.failed,
       data: render_many(data.challenges, ChallengeView, "challenge.json"),
     }
   end


### PR DESCRIPTION
**** Breaking App changes ****

This changes the response from `/api/challenges` endpoint to:

```
{
    "data": [...],
    "failed": 25,
    "issued": 29,
    "successful": 4,
    "totalOngoing": 0
}

- Aggregate past 24 hr challenges
- Move `current_time/0` to util module