### PR TITLE
Route all unknown paths to 404

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -14,7 +14,7 @@ config :blockchain_api,
 config :blockchain_api, BlockchainAPIWeb.Endpoint,
   url: [host: "localhost"],
   secret_key_base: "OOLfw0Ez2rPqx6IOAsgbvj+5SxUhPuZ1zm6mHP0t2ETXk/8gT0guAres57j9LffB",
-  render_errors: [view: BlockchainAPIWeb.ErrorView, accepts: ~w(json)],
+  render_errors: [view: BlockchainAPIWeb.ErrorView, format: "json", accepts: ~w(json)],
   pubsub: [name: BlockchainAPI.PubSub, adapter: Phoenix.PubSub.PG2]
 
 # Configures Elixir's Logger

--- a/lib/blockchain_api_web/controllers/four_oh_four_controller.ex
+++ b/lib/blockchain_api_web/controllers/four_oh_four_controller.ex
@@ -1,0 +1,10 @@
+defmodule BlockchainAPIWeb.FourOhFourController do
+  use BlockchainAPIWeb, :controller
+
+  def index(conn, _params) do
+    conn
+    |> put_status(:not_found)
+    |> put_view(BlockchainAPIWeb.ErrorView)
+    |> render("404.json")
+  end
+end

--- a/lib/blockchain_api_web/router.ex
+++ b/lib/blockchain_api_web/router.ex
@@ -35,5 +35,6 @@ defmodule BlockchainAPIWeb.Router do
 
   scope "/", BlockchainAPIWeb do
     get "/", HealthCheckController, :index
+    get "/*path", FourOhFourController, :index
   end
 end


### PR DESCRIPTION
Prevents crashing horribly when an unknown route is fetched by some random bot online