### PR TITLE
add online/offline status to owned hotspots

### DIFF
--- a/lib/blockchain_api/query/account_transaction.ex
+++ b/lib/blockchain_api/query/account_transaction.ex
@@ -15,8 +15,7 @@ defmodule BlockchainAPI.Query.AccountTransaction do
     Schema.Hotspot,
     Schema.SecurityTransaction,
     Schema.RewardTxn,
-    Schema.HotspotActivity,
-    Schema.Block
+    Schema.HotspotActivity
   }
 
   def create(attrs \\ %{}) do
@@ -95,6 +94,8 @@ defmodule BlockchainAPI.Query.AccountTransaction do
   end
 
   def get_gateways(address, _params \\ %{}) do
+    current_height = Query.Block.get_latest_height()
+
     status_query = from(
       ha in HotspotActivity,
       group_by: ha.gateway,
@@ -103,10 +104,6 @@ defmodule BlockchainAPI.Query.AccountTransaction do
         challenge_height: max(ha.poc_req_txn_block_height)
       }
     )
-
-    %Block{height: current_height} =
-      from(b in Block, order_by: [desc: :height], limit: 1)
-      |> Repo.one()
 
     query = from(
       at in AccountTransaction,

--- a/lib/blockchain_api/query/block.ex
+++ b/lib/blockchain_api/query/block.ex
@@ -59,6 +59,11 @@ defmodule BlockchainAPI.Query.Block do
     Repo.all(query)
   end
 
+  def get_latest_height() do
+    query = from b in Block, select: max(b.height)
+    Repo.one(query)
+  end
+
   #==================================================================
   # Helper functions
   #==================================================================


### PR DESCRIPTION
example response:
```
{
"data": [
{
"account_address": "14bgUqZ4d47TVQFWmXGTytd748bTjqvom5L8yzPaPz5WEnH3HE6",
"gateway": "11TUDQEnZa8KXwuCNPVjLWboFGnVskfua1dRkEvmaNgriMWBwAf",
"gateway_fee": 0,
"gateway_hash": "12sAirf5EDBAG3Qfp6m9TqtZ4x2XvbWKCEi4X8QTUKX8zcJfTa5",
"lat": 37.76190586430353,
"lng": -122.43593124113261,
"location": "8c283082d5485ff",
"location_fee": 0,
"location_hash": "12sAirf5EDBAG3Qfp6m9TqtZ4x2XvbWKCEi4X8QTUKX8zcJfTa5",
"location_nonce": 0,
"long_city": "San Francisco",
"long_country": "United States",
"long_state": "California",
"long_street": "Collingwood Street",
"owner": "14bgUqZ4d47TVQFWmXGTytd748bTjqvom5L8yzPaPz5WEnH3HE6",
"score": 0.2698,
"short_city": "SF",
"short_country": "US",
"short_state": "CA",
"short_street": "Collingwood St",
"status": "online"
}
]
}
```