### PR TITLE
Add activity support for hotspot in consensus

### DIFF
--- a/lib/blockchain_api/query/hotspot_activity.ex
+++ b/lib/blockchain_api/query/hotspot_activity.ex
@@ -97,7 +97,11 @@ defmodule BlockchainAPI.Query.HotspotActivity do
       poc_rx_challenge_id: entry.poc_rx_challenge_id,
       poc_score: entry.poc_score,
       poc_score_delta: entry.poc_score_delta,
-      rapid_decline: entry.rapid_decline
+      rapid_decline: entry.rapid_decline,
+      in_consensus: entry.in_consensus,
+      election_id: entry.election_id,
+      election_txn_block_height: entry.election_txn_block_height,
+      election_block_height: entry.election_block_height
     }
   end
 end

--- a/lib/blockchain_api/schema/hotspot_activity.ex
+++ b/lib/blockchain_api/schema/hotspot_activity.ex
@@ -18,7 +18,11 @@ defmodule BlockchainAPI.Schema.HotspotActivity do
     :poc_rx_challenge_id,
     :poc_score,
     :poc_score_delta,
-    :rapid_decline
+    :rapid_decline,
+    :in_consensus,
+    :election_id,
+    :election_block_height,
+    :election_txn_block_height
   ]
 
   @derive {Jason.Encoder, only: @fields}
@@ -37,6 +41,10 @@ defmodule BlockchainAPI.Schema.HotspotActivity do
     field :poc_score, :float, null: true
     field :poc_score_delta, :float, null: true
     field :rapid_decline, :boolean, null: true
+    field :in_consensus, :boolean, null: true, default: :false
+    field :election_id, :integer, null: true
+    field :election_block_height, :integer, null: true
+    field :election_txn_block_height, :integer, null: true
 
     timestamps()
   end

--- a/priv/repo/migrations/20190508201122_add_hotspot_activity_table.exs
+++ b/priv/repo/migrations/20190508201122_add_hotspot_activity_table.exs
@@ -17,6 +17,10 @@ defmodule BlockchainAPI.Repo.Migrations.AddHotspotActivityTable do
       add :poc_score, :float, null: true
       add :poc_score_delta, :float, null: true
       add :rapid_decline, :boolean, null: true, default: :false
+      add :in_consensus, :boolean, null: true, default: :false
+      add :election_id, :integer, null: true
+      add :election_block_height, :bigint, null: true
+      add :election_txn_block_height, :bigint, null: true
 
       timestamps()
     end


### PR DESCRIPTION
All the other fields would be null in the `/api/hotspot/<address>/activity` response except these new ones which I've added.

```"election_block_height": 31,
"election_id": 2,
"election_txn_block_height": 93,
"gateway": "11MFNwMS56vpKvK4iBvMfp3dipCpQA623XaFDvoCu2AACKvwcSX",
"id": 71
```