### PR TITLE
Remove unique pending location index

### DIFF
--- a/lib/blockchain_api/schema/pending_location.ex
+++ b/lib/blockchain_api/schema/pending_location.ex
@@ -44,7 +44,6 @@ defmodule BlockchainAPI.Schema.PendingLocation do
     |> validate_required(@fields)
     |> foreign_key_constraint(:owner)
     |> unique_constraint(:unique_pending_location, name: :unique_pending_location)
-    |> unique_constraint(:unique_pending_owner_gateway_nonce, name: :unique_pending_owner_gateway_nonce)
   end
 
   def encode_model(pending_location) do

--- a/priv/repo/migrations/20190804014105_remove_pending_location_constraint.exs
+++ b/priv/repo/migrations/20190804014105_remove_pending_location_constraint.exs
@@ -1,0 +1,8 @@
+defmodule BlockchainAPI.Repo.Migrations.RemovePendingLocationConstraint do
+  use Ecto.Migration
+
+  def change do
+    drop_if_exists(index("pending_locations", ["unique_pending_owner_gateway_nonce"], name: "unique_pending_owner_gateway_nonce"))
+  end
+
+end


### PR DESCRIPTION
This should allow multiple pending_location transactions by the same user for the same hotspot, in case one of which errors out a later block if it fails validation, while the other succeeds. The remaining would get invalidated anyway and error out in the db.