### PR TITLE
Defatult sync percent to 1.0 withing 5 blocks

### DIFF
--- a/lib/blockchain_api/query/hotspot_status.ex
+++ b/lib/blockchain_api/query/hotspot_status.ex
@@ -45,7 +45,11 @@ defmodule BlockchainAPI.Query.HotspotStatus do
         api_height = Query.Block.get_latest_height()
         case :libp2p_peer.signed_metadata_get(peer, <<"height">>, :undefined) do
           height when is_integer(height) and height > 0 ->
-            height/api_height
+            case abs(api_height - height) <= 5 do
+              true -> 1.0
+              false ->
+                height/api_height
+            end
           _ -> nil
         end
     end


### PR DESCRIPTION
So if the absolute difference between api height and hotspot height is within 5 blocks, we default to 1.0 otherwise we just show the percent.