### PR TITLE
Return challenges witnessed, completed with reward

### DIFF
--- a/lib/blockchain_api/query/hotspot_activity.ex
+++ b/lib/blockchain_api/query/hotspot_activity.ex
@@ -152,6 +152,7 @@ defmodule BlockchainAPI.Query.HotspotActivity do
           where: s.timestamp < ^reward_time,
           select: count(s.id)
         )
+        |> Repo.one()
     end
   end
 

--- a/test/blockchain_api/query/hotspot_activity_test.exs
+++ b/test/blockchain_api/query/hotspot_activity_test.exs
@@ -7,13 +7,25 @@ defmodule BlockchainAPI.Query.HotspotActivityTest do
     Schema
   }
 
-  setup do
-    insert_hotspot_activity()
-    :ok
-  end
-
   describe "challenges_witnessed/1" do
     test "returns count of challenges witnessed since last reward" do
+      insert_hotspot_activity()
+      challenges_witnessed =
+        from(
+          ha in Schema.HotspotActivity,
+          where: not is_nil(ha.reward_block_time),
+          where: ha.reward_type == ^"poc_witnesses",
+          order_by: [desc: ha.reward_block_time],
+          limit: 1
+        )
+        |> Repo.one()
+        |> Query.HotspotActivity.challenges_witnessed()
+
+      assert challenges_witnessed == 1
+    end
+
+    test "returns all challenges witnessed when there is no  previous reward" do
+      insert_hotspot_activity(2)
       challenges_witnessed =
         from(
           ha in Schema.HotspotActivity,
@@ -31,6 +43,7 @@ defmodule BlockchainAPI.Query.HotspotActivityTest do
 
   describe "challenges_completed/1" do
     test "returns count of challenges completed since last reward" do
+      insert_hotspot_activity()
       challenges_completed =
         from(
           ha in Schema.HotspotActivity,
@@ -43,6 +56,22 @@ defmodule BlockchainAPI.Query.HotspotActivityTest do
         |> Query.HotspotActivity.challenges_completed()
 
       assert challenges_completed == 1
+    end
+
+    test "returns all challenges completed when there is no previous reward" do
+      insert_hotspot_activity(2)
+      challenges_witnessed =
+        from(
+          ha in Schema.HotspotActivity,
+          where: not is_nil(ha.reward_block_time),
+          where: ha.reward_type == ^"poc_witnesses",
+          order_by: [desc: ha.reward_block_time],
+          limit: 1
+        )
+        |> Repo.one()
+        |> Query.HotspotActivity.challenges_witnessed()
+
+      assert challenges_witnessed == 1
     end
   end
 end

--- a/test/support/test_helpers.ex
+++ b/test/support/test_helpers.ex
@@ -65,7 +65,7 @@ defmodule BlockchainAPI.TestHelpers do
       end)
   end
 
-  def insert_hotspot_activity do
+  def insert_hotspot_activity(num_blocks \\ 10) do
     fake_location = Util.h3_to_string(631210983218633727)
     {:ok, account} = Query.Account.create(%{
       name: "Jane Doe",
@@ -89,7 +89,7 @@ defmodule BlockchainAPI.TestHelpers do
         short_street: "Las Colindas Rd"
       }
     {:ok, hotspot} = Query.Hotspot.create(hotspot_map)
-    Range.new(1, 10)
+    Range.new(1, num_blocks)
     |> Enum.map(
       fn(h) ->
         block_map = %{hash: :crypto.strong_rand_bytes(32), height: h, round: h, time: h}


### PR DESCRIPTION
https://app.clubhouse.io/hlm/story/4549/ux-api-to-support-listing-how-many-challenges-completed-or-witnessed-in-an-epoch-per-hotspot

This adds new fields `challenges_witnessed` and `challenges_completed` in responses for epoch rewards. The challenges witnessed field is calculated by adding the number of `POCWitness` entries with a timestamp between the current `reward_block_time` and the previous `reward_block_time`. The challenges completed field is calculated by adding the number of `POCReceipt` entries with a timestamp between the current `reward_block_time` and the previous `reward_block_time`. By looking at the data it is my understanding that challenge witnessed and completed events don't occur in the same block as epoch rewards, is that correct?

Let me know if I missed anything or if I misunderstood what it means for a challenge to be witnessed or completed in an epoch.