### PR TITLE
Add timestamp for rapid decline hotspot activity

### DIFF
--- a/lib/blockchain_api/committer.ex
+++ b/lib/blockchain_api/committer.ex
@@ -583,12 +583,11 @@ defmodule BlockchainAPI.Committer do
           poc_score_delta: rx_score_delta
         })
 
-        _ = rapid_decline(rx_gateway)
-
+        rapid_decline(rx_gateway, time)
     end
   end
 
-  defp rapid_decline(challengee) do
+  defp rapid_decline(challengee, time) do
     challenge_results = Query.POCPathElement.get_last_ten(challengee)
     case length(challenge_results) == 10 do
       false -> :ok
@@ -598,7 +597,7 @@ defmodule BlockchainAPI.Committer do
           false ->
             case Enum.count(challenge_results, fn(res) -> res == "failure" end) do
               c when c >= 4 ->
-                  Query.HotspotActivity.create(%{gateway: challengee, rapid_decline: true})
+                  Query.HotspotActivity.create(%{gateway: challengee, rapid_decline: true, poc_rx_txn_block_time: time})
               _ ->
                 :ok
             end


### PR DESCRIPTION
https://app.clubhouse.io/hlm/story/4595/rapidly-declining-score-activity-in-api-does-not-have-a-timestamp

This adds a timestamp in the `poc_rx_txn_block_time` field when creating a hotspot activity entry for rapidly declining score.