### PR TITLE
Handle unknown gw error in updater

### DIFF
--- a/lib/blockchain_api/periodic_updater.ex
+++ b/lib/blockchain_api/periodic_updater.ex
@@ -50,10 +50,13 @@ defmodule BlockchainAPI.PeriodicUpdater do
         hotspots_with_location_in_ledger = hotspots_with_no_location_in_db
                                            |> Enum.reduce([],
                                              fn(hotspot, acc) ->
-                                               {:ok, gateway} = :blockchain_ledger_v1.find_gateway_info(hotspot.address, ledger)
-                                               case :blockchain_ledger_gateway_v2.location(gateway) do
-                                                 :undefined -> acc
-                                                 loc -> [{hotspot, loc} | acc]
+                                               case :blockchain_ledger_v1.find_gateway_info(hotspot.address, ledger) do
+                                                 {:error, _} -> acc
+                                                 {:ok, gateway} ->
+                                                   case :blockchain_ledger_gateway_v2.location(gateway) do
+                                                     :undefined -> acc
+                                                     loc -> [{hotspot, loc} | acc]
+                                                   end
                                                end
                                              end)
         Logger.debug("hotspots_with_location_in_ledger: #{inspect(hotspots_with_location_in_ledger)}")


### PR DESCRIPTION
So this seems to happen when an API instance is still syncing and tries to update a hotspot's location, but since it's chain hasn't moved ahead, it's possible that the ledger is lagging and the hotspot was added at a later block. But since all the instances are reading from the same DB now, I'm seeing this pop up.

This just handles it more gracefully.