### PR TITLE
Fix notifier client post in rewards_notifier

### DIFF
--- a/lib/blockchain_api/notifiers/notifier_client.ex
+++ b/lib/blockchain_api/notifiers/notifier_client.ex
@@ -12,10 +12,10 @@ defmodule BlockchainAPI.NotifierClient do
     ]
   end
 
-  defp to_payload(data, message, _send_address, opts) do
+  defp to_payload(data, message, send_address, opts) do
     %{
       :app_id => Application.fetch_env!(:blockchain_api, :onesignal_app_id),
-      :filters => [%{:field => "tag", :key => "address", :relation => "=", :value => data.address}],
+      :filters => [%{:field => "tag", :key => "address", :relation => "=", :value => send_address}],
       :contents => %{:en => message},
       :data => data
     }

--- a/lib/blockchain_api/notifiers/rewards_notifier.ex
+++ b/lib/blockchain_api/notifiers/rewards_notifier.ex
@@ -30,7 +30,7 @@ defmodule BlockchainAPI.RewardsNotifier do
     Logger.info("Notifying for weekly rewards")
     RewardTxn.get_from_last_week()
     |> Enum.map(fn reward ->
-      @notifier_client.post(reward_data(reward), message(reward), %{delayed_option: "timezone", delivery_time_of_day: "10:00AM"})
+      @notifier_client.post(reward_data(reward), message(reward), reward.account, %{delayed_option: "timezone", delivery_time_of_day: "10:00AM"})
     end)
     :timer.apply_after(@interval, __MODULE__, :send_notifications, [])
   end


### PR DESCRIPTION
Fixes an error with sending rewards notifications to OneSignal.