### PR TITLE
Refactor hotspot notifications data

### DIFF
--- a/lib/blockchain_api/job/submit_gateway.ex
+++ b/lib/blockchain_api/job/submit_gateway.ex
@@ -1,6 +1,10 @@
 defmodule BlockchainAPI.Job.SubmitGateway do
-  alias BlockchainAPI.Query.PendingGateway
-  alias BlockchainAPI.Util
+  alias BlockchainAPI.{
+    Query.Hotspot,
+    Query.PendingGateway,
+    HotspotNotifier,
+    Util
+  }
   require Logger
 
   @blacklisted_owner BlockchainAPI.Util.string_to_bin("14CJX5YCRf94kbhL9PPn58SL9EzqUGsrALeaEar4UikM4EB3Mx7")
@@ -26,7 +30,7 @@ defmodule BlockchainAPI.Job.SubmitGateway do
           case res do
             :ok ->
               Logger.info("Txn: #{Util.bin_to_string(:blockchain_txn.hash(txn))} accepted!")
-              notify_gateway_success(txn)
+              notify_gateway_success(pending_gateway, txn)
 
               pending_gateway
               |> PendingGateway.update!(%{status: "cleared"})
@@ -37,7 +41,7 @@ defmodule BlockchainAPI.Job.SubmitGateway do
                   inspect(reason)
                 }"
                   )
-              notify_gateway_failure(txn, pending_gateway)
+              notify_gateway_failure(pending_gateway)
 
               pending_gateway
               |> PendingGateway.update!(%{status: "error"})
@@ -46,16 +50,12 @@ defmodule BlockchainAPI.Job.SubmitGateway do
     end
   end
 
-  defp notify_gateway_success(txn) do
-    type = :blockchain_txn.type(txn)
-    ledger =
-      :blockchain_worker.blockchain()
-      |> :blockchain.ledger()
-    HotspotNotifier.send_new_hotspot_notification(txn, type, ledger)
+  defp notify_gateway_success(pending_gateway, txn) do
+    HotspotNotifier.send_new_hotspot_notification(txn, pending_gateway)
   end
 
-  defp notify_gateway_failure(txn, pending_gateway) do
-    case Query.Hotspot.get(pending_gateway.gateway) do
+  defp notify_gateway_failure(pending_gateway) do
+    case Hotspot.get(pending_gateway.gateway) do
       nil ->
         HotspotNotifier.send_add_hotspot_failed(:timed_out, pending_gateway)
 

--- a/lib/blockchain_api/job/submit_location.ex
+++ b/lib/blockchain_api/job/submit_location.ex
@@ -1,6 +1,9 @@
 defmodule BlockchainAPI.Job.SubmitLocation do
-  alias BlockchainAPI.Query.PendingLocation
-  alias BlockchainAPI.Util
+  alias BlockchainAPI.{
+    HotspotNotifier,
+    Query.PendingLocation,
+    Util
+  }
   require Logger
 
   @blacklisted_owner BlockchainAPI.Util.string_to_bin("14CJX5YCRf94kbhL9PPn58SL9EzqUGsrALeaEar4UikM4EB3Mx7")

--- a/lib/blockchain_api/notifier.ex
+++ b/lib/blockchain_api/notifier.ex
@@ -2,7 +2,7 @@ defmodule BlockchainAPI.Notifier do
   use GenServer
   require Logger
 
-  alias BlockchainAPI.{HotspotNotifier, PaymentsNotifier}
+  alias BlockchainAPI.PaymentsNotifier
 
   # ==================================================================
   # API
@@ -26,7 +26,7 @@ defmodule BlockchainAPI.Notifier do
   end
 
   @impl true
-  def handle_cast({:notify, block, ledger}, state) do
+  def handle_cast({:notify, block, _ledger}, state) do
     case :blockchain_block.transactions(block) do
       [] ->
         :ok

--- a/lib/blockchain_api/notifiers/hotspot_notifier.ex
+++ b/lib/blockchain_api/notifiers/hotspot_notifier.ex
@@ -1,23 +1,22 @@
 defmodule BlockchainAPI.HotspotNotifier do
   alias BlockchainAPI.{Schema.Hotspot, Util}
 
-  def send_new_hotspot_notification(txn, type, ledger) do
-    map = Hotspot.map(type, txn, ledger)
+  def send_new_hotspot_notification(txn, pending_gateway) do
     data = %{
-      hotspot_address: Util.bin_to_string(map.address),
-      owner: Util.bin_to_string(map.owner),
+      hotspot_address: Util.bin_to_string(pending_gateway.gateway),
+      owner: Util.bin_to_string(pending_gateway.owner),
       hash: Util.bin_to_string(txn.hash),
       type: "addHotspotSuccess"
     }
-    animal_name = Hotspot.animal_name(map.address)
+    animal_name = Hotspot.animal_name(data.address)
     message = "#{animal_name} has been added to the network!"
     Util.notifier_client().post(data, message, data.owner)
   end
 
   def send_add_hotspot_failed(:timed_out, pending_gateway) do
     data = %{
-      hotspot_address: pending_gateway.gateway,
-      owner: pending_gateway.owner,
+      hotspot_address: Util.bin_to_string(pending_gateway.gateway),
+      owner: Util.bin_to_string(pending_gateway.owner),
       type: "addHotspotTimeOut"
     }
     message = "Unable to Add Hotspot. Transaction Timed Out."
@@ -26,8 +25,8 @@ defmodule BlockchainAPI.HotspotNotifier do
 
   def send_add_hotspot_failed(:already_exists, pending_gateway) do
     data = %{
-      hotspot_address: pending_gateway.gateway,
-      owner: pending_gateway.owner,
+      hotspot_address: Util.bin_to_string(pending_gateway.gateway),
+      owner: Util.bin_to_string(pending_gateway.owner),
       type: "addHotspotAlreadyExists"
     }
     message = "Unable to Add Hotspot. Hotspot Already on Blockchain."
@@ -36,8 +35,8 @@ defmodule BlockchainAPI.HotspotNotifier do
 
   def send_confirm_location_failed(pending_location) do
     data = %{
-      hotspot_address: pending_location.gateway,
-      owner: pending_location.owner,
+      hotspot_address: Util.bin_to_string(pending_location.gateway),
+      owner: Util.bin_to_string(pending_location.owner),
       type: "assertLocationFailure"
     }
     animal_name = Hotspot.animal_name(pending_location)

--- a/lib/blockchain_api/query/hotspot.ex
+++ b/lib/blockchain_api/query/hotspot.ex
@@ -13,6 +13,12 @@ defmodule BlockchainAPI.Query.Hotspot do
     |> Repo.all()
   end
 
+  def get(address) do
+    Hotspot
+    |> where([h], h.address == ^address)
+    |> Repo.one()
+  end
+
   def get!(address) do
     Hotspot
     |> where([h], h.address == ^address)


### PR DESCRIPTION
Adds the transaction hash to the payload and renames the `address` field to `hotspot_address`.