### PR TITLE
Check pending txns getting cleared on chain

### DIFF
--- a/lib/blockchain_api/periodic_cleaner.ex
+++ b/lib/blockchain_api/periodic_cleaner.ex
@@ -54,7 +54,7 @@ defmodule BlockchainAPI.PeriodicCleaner do
     |> Enum.reject(fn entry -> pending_txn_appeared_on_chain?(mod, entry, chain) end)
     |> Enum.filter(fn entry -> filter_long_standing?(entry, chain) end)
     |> Enum.map(fn p ->
-      Logger.info("Marking txn: #{Util.bin_to_string(p.hash)} as error, pending_txn_submission_height: #{p.submit_height}")
+      Logger.error("Marking txn: #{Util.bin_to_string(p.hash)} as error, pending_txn_submission_height: #{p.submit_height}")
       apply(mod, :update!, [p, %{status: "error"}])
     end)
   end
@@ -76,6 +76,7 @@ defmodule BlockchainAPI.PeriodicCleaner do
           true ->
             # pending txn appeared on chain
             # mark it as cleared and return true for rejection
+            Logger.info("Marking txn: #{Util.bin_to_string(entry.hash)} as cleared!")
             apply(mod, :update!, [entry, %{status: "cleared"}])
             true
         end


### PR DESCRIPTION
Draft for now since I need to test it more.

The goal here is to check whether a pending txn appeared on chain _before_ marking it as error/clear in the pending tables. Since it's possible that the callback may not get fired from core's txn_manager (due to any crash in the api), we need to check that the pending txn got mined or not. Before this we were only checking 20 blocks since pending txn submission height without checking whether the txn appeared in a block.

I've upped the `max_height` to 50 blocks as well.

Doing this would keep the pending txns around for a little longer however.