### PR TITLE
Make rewards notifications to onesignal idempotent

### DIFF
--- a/lib/blockchain_api/notifiers/rewards_notifier.ex
+++ b/lib/blockchain_api/notifiers/rewards_notifier.ex
@@ -42,7 +42,8 @@ defmodule BlockchainAPI.RewardsNotifier do
 
       Util.notifier_client().post(reward, message(reward), reward.address, %{
         delayed_option: "timezone",
-        delivery_time_of_day: "10:00AM"
+        delivery_time_of_day: "10:00AM",
+        external_id: UUID.uuid5(:oid, "#{reward.address}-#{Timex.today() |> Date.to_string()}")
       })
     end)
 

--- a/mix.exs
+++ b/mix.exs
@@ -70,6 +70,7 @@ defmodule BlockchainAPI.MixProject do
       {:logger_file_backend, "~> 0.0.10"},
       {:appsignal,
         git: "https://github.com/appsignal/appsignal-elixir", branch: "master"},
+      {:uuid, "~> 1.1"},
 
       # blockchain requirements
       {:blockchain, git: "git@github.com:helium/blockchain-core.git", branch: "master"},

--- a/mix.lock
+++ b/mix.lock
@@ -73,4 +73,5 @@
   "tzdata": {:hex, :tzdata, "1.0.1", "f6027a331af7d837471248e62733c6ebee86a72e57c613aa071ebb1f750fc71a", [:mix], [{:hackney, "~> 1.0", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm"},
   "unsafe": {:hex, :unsafe, "1.0.1", "a27e1874f72ee49312e0a9ec2e0b27924214a05e3ddac90e91727bc76f8613d8", [:mix], [], "hexpm"},
+  "uuid": {:hex, :uuid, "1.1.8", "e22fc04499de0de3ed1116b770c7737779f226ceefa0badb3592e64d5cfb4eb9", [:mix], [], "hexpm"},
 }


### PR DESCRIPTION
This adds an external id so OneSignal won't send the same notification multiple times.