### PR TITLE
Add cache for stats

### DIFF
--- a/lib/blockchain_api/application.ex
+++ b/lib/blockchain_api/application.ex
@@ -88,6 +88,10 @@ defmodule BlockchainAPI.Application do
       Supervisor.child_spec(Cachex,
         start: {Cachex, :start_link, [:account_txn_cache, [limit: cache_limit()]]},
         id: :account_txn_cache
+      ),
+      Supervisor.child_spec(Cachex,
+        start: {Cachex, :start_link, [:stats_cache, [limit: cache_limit()]]},
+        id: :stats_cache
       )
     ]
 


### PR DESCRIPTION
Note that the cache invalidation timeout is set to 30 minutes instead of the standard 2 minutes for the other caches. Comments in code.