### PR TITLE
Add cache for hotspot stats

### DIFF
--- a/lib/blockchain_api/application.ex
+++ b/lib/blockchain_api/application.ex
@@ -73,6 +73,7 @@ defmodule BlockchainAPI.Application do
       {PeriodicCleaner, []},
       {PeriodicUpdater, []},
       {Notifier, []},
+      {Cache.HotspotStats, []},
       {RewardsNotifier, []},
       Supervisor.child_spec(Cachex,
         start: {Cachex, :start_link, [:challenge_cache, [limit: cache_limit()]]},

--- a/lib/blockchain_api/application.ex
+++ b/lib/blockchain_api/application.ex
@@ -6,7 +6,7 @@ defmodule BlockchainAPI.Application do
   use Application
   alias Honeydew.EctoPollQueue
   alias BlockchainAPI.Repo
-  alias BlockchainAPI.Watcher
+  alias BlockchainAPI.{Cache, Watcher}
   alias BlockchainAPI.{PeriodicCleaner, PeriodicUpdater}
   alias BlockchainAPI.{Notifier, RewardsNotifier}
   alias BlockchainAPI.Job.{SubmitPayment, SubmitGateway, SubmitLocation, SubmitCoinbase}

--- a/lib/blockchain_api/cache/hotspot_stats.ex
+++ b/lib/blockchain_api/cache/hotspot_stats.ex
@@ -1,0 +1,83 @@
+defmodule BlockchainAPI.Cache.HotspotStats do
+  use GenServer
+
+  alias BlockchainAPI.Query.HotspotStats
+
+  def start_link(args) do
+    GenServer.start_link(__MODULE__, args, name: __MODULE__)
+  end
+
+  def update_cache do
+    GenServer.cast(__MODULE__, :update_cache)
+  end
+
+  def init(_) do
+    cache = :ets.new(:hotspot_stats, [:named_table])
+    insert_stats(cache)
+    {:ok, %{cache: cache}}
+  end
+
+  def handle_cast(:update_cache, %{cache: cache} = state) do
+    insert_stats(cache)
+    {:ok, state}
+  end
+
+  defp insert_stats(cache) do
+    insert_challenges_completed(cache)
+    insert_consensus_groups(cache)
+    insert_hlm_earned(cache)
+    insert_earning_percentile(cache)
+    insert_challenges_witnessed(cache)
+    insert_witnessed_percentile(cache)
+    insert_furthest_witness(cache)
+    insert_furthest_witness_percentile(cache)
+  end
+
+  defp insert_challenges_completed(cache) do
+    HotspotStats.challenges_completed() 
+    |> set_cache(cache, :challenges_completed)
+  end
+
+  defp insert_consensus_groups_cache(cache) do
+    HotspotStats.consensus_groups() 
+    |> set_cache(cache, :consensus_groups)
+  end
+
+  defp insert_hlm_earned_cache(cache) do
+    HotspotStats.hlm_earned() 
+    |> set_cache(cache, :hlm_earned)
+  end
+
+  defp insert_earning_percentile(cache) do
+    HotspotStats.earning_percentiles()
+    |> set_cache(cache, :earning_percentile)
+  end
+
+  defp insert_challenges_witnessed(cache) do
+    HotspotStats.challenges_witnessed() 
+    |> set_cache(cache, :challenges_witnessed)
+  end
+
+  defp insert_witnessed_percentile(cache) do
+    HotspotStats.witnessed_percentiles()
+    |> set_cache(cache, :witnessed_percentile)
+  end
+
+  defp insert_furthest_witness(cache) do
+    HotspotStats.furthest_witnesses()
+    |> set_cache(cache, :furthest_witness)
+  end
+
+  defp insert_furthest_witness_percentile(cache) do
+    HotspotStats.furthest_witness_percentiles()
+    |> set_cache(cache, :furthest_witness_percentile)
+  end
+
+  defp set_cache(map, cache, stat) do
+    Enum.each(map, fn {time, entries} ->
+      Enum.each(entries, fn {address, value} ->
+        :ets.insert(cache, {address, stat, time}, value)
+      end)
+    end)
+  end
+end

--- a/lib/blockchain_api/cache/hotspot_stats.ex
+++ b/lib/blockchain_api/cache/hotspot_stats.ex
@@ -3,6 +3,8 @@ defmodule BlockchainAPI.Cache.HotspotStats do
 
   alias BlockchainAPI.Query.HotspotStats
 
+  @cache :hotspot_stats
+
   def start_link(args) do
     GenServer.start_link(__MODULE__, args, name: __MODULE__)
   end
@@ -12,7 +14,7 @@ defmodule BlockchainAPI.Cache.HotspotStats do
   end
 
   def init(_) do
-    cache = :ets.new(:hotspot_stats, [:named_table])
+    cache = :ets.new(@cache, [:named_table])
     insert_stats(cache)
     {:ok, %{cache: cache}}
   end
@@ -20,6 +22,78 @@ defmodule BlockchainAPI.Cache.HotspotStats do
   def handle_cast(:update_cache, %{cache: cache} = state) do
     insert_stats(cache)
     {:ok, state}
+  end
+
+  def challenges_completed(address) do
+    %{
+      "24h" => :ets.lookup(@cache, {address, :challenges_completed, "24h"}),
+      "7d" => :ets.lookup(@cache, {address, :challenges_completed, "7d"}),
+      "30d" => :ets.lookup(@cache, {address, :challenges_completed, "30d"}),
+      "all_time" => :ets.lookup(@cache, {address, :challenges_completed, "all_time"})
+    }
+  end
+
+  def consensus_groups(address) do
+    %{
+      "24h" => :ets.lookup(@cache, {address, :consensus_groups, "24h"}),
+      "7d" => :ets.lookup(@cache, {address, :consensus_groups, "7d"}),
+      "30d" => :ets.lookup(@cache, {address, :consensus_groups, "30d"}),
+      "all_time" => :ets.lookup(@cache, {address, :consensus_groups, "all_time"})
+    }
+  end
+
+  def hlm_earned(address) do
+    %{
+      "24h" => :ets.lookup(@cache, {address, :hlm_earned, "24h"}),
+      "7d" => :ets.lookup(@cache, {address, :hlm_earned, "7d"}),
+      "30d" => :ets.lookup(@cache, {address, :hlm_earned, "30d"}),
+      "all_time" => :ets.lookup(@cache, {address, :hlm_earned, "all_time"})
+    }
+  end
+
+  def earning_percentile(address) do
+    %{
+      "24h" => :ets.lookup(@cache, {address, :earning_percentile, "24h"}),
+      "7d" => :ets.lookup(@cache, {address, :earning_percentile, "7d"}),
+      "30d" => :ets.lookup(@cache, {address, :earning_percentile, "30d"}),
+      "all_time" => :ets.lookup(@cache, {address, :earning_percentile, "all_time"})
+    }
+  end
+
+  def challenges_witnessed(address) do
+    %{
+      "24h" => :ets.lookup(@cache, {address, :challenges_witnessed, "24h"}),
+      "7d" => :ets.lookup(@cache, {address, :challenges_witnessed, "7d"}),
+      "30d" => :ets.lookup(@cache, {address, :challenges_witnessed, "30d"}),
+      "all_time" => :ets.lookup(@cache, {address, :challenges_witnessed, "all_time"})
+    }
+  end
+
+  def witnessed_percentile(address) do
+    %{
+      "24h" => :ets.lookup(@cache, {address, :witnessed_percentile, "24h"}),
+      "7d" => :ets.lookup(@cache, {address, :witnessed_percentile, "7d"}),
+      "30d" => :ets.lookup(@cache, {address, :witnessed_percentile, "30d"}),
+      "all_time" => :ets.lookup(@cache, {address, :witnessed_percentile, "all_time"})
+    }
+  end
+
+  def furthest_witness(address) do
+    %{
+      "24h" => :ets.lookup(@cache, {address, :furthest_witness, "24h"}),
+      "7d" => :ets.lookup(@cache, {address, :furthest_witness, "7d"}),
+      "30d" => :ets.lookup(@cache, {address, :furthest_witness, "30d"}),
+      "all_time" => :ets.lookup(@cache, {address, :furthest_witness, "all_time"})
+    }
+  end
+
+  def furthest_witness_percentile(address) do
+    %{
+      "24h" => :ets.lookup(@cache, {address, :furthest_witness_percentile, "24h"}),
+      "7d" => :ets.lookup(@cache, {address, :furthest_witness_percentile, "7d"}),
+      "30d" => :ets.lookup(@cache, {address, :furthest_witness_percentile, "30d"}),
+      "all_time" => :ets.lookup(@cache, {address, :furthest_witness_percentile, "all_time"})
+    }
   end
 
   defp insert_stats(cache) do
@@ -34,32 +108,32 @@ defmodule BlockchainAPI.Cache.HotspotStats do
   end
 
   defp insert_challenges_completed(cache) do
-    HotspotStats.challenges_completed() 
+    HotspotStats.challenges_completed_map()
     |> set_cache(cache, :challenges_completed)
   end
 
-  defp insert_consensus_groups_cache(cache) do
-    HotspotStats.consensus_groups() 
+  defp insert_consensus_groups(cache) do
+    HotspotStats.consensus_groups_map()
     |> set_cache(cache, :consensus_groups)
   end
 
-  defp insert_hlm_earned_cache(cache) do
-    HotspotStats.hlm_earned() 
+  defp insert_hlm_earned(cache) do
+    HotspotStats.hlm_earned_map()
     |> set_cache(cache, :hlm_earned)
   end
 
   defp insert_earning_percentile(cache) do
-    HotspotStats.earning_percentiles()
+    HotspotStats.earning_percentiles_map()
     |> set_cache(cache, :earning_percentile)
   end
 
   defp insert_challenges_witnessed(cache) do
-    HotspotStats.challenges_witnessed() 
+    HotspotStats.challenges_witnessed_map()
     |> set_cache(cache, :challenges_witnessed)
   end
 
   defp insert_witnessed_percentile(cache) do
-    HotspotStats.witnessed_percentiles()
+    HotspotStats.witnessed_percentiles_map()
     |> set_cache(cache, :witnessed_percentile)
   end
 
@@ -76,7 +150,7 @@ defmodule BlockchainAPI.Cache.HotspotStats do
   defp set_cache(map, cache, stat) do
     Enum.each(map, fn {time, entries} ->
       Enum.each(entries, fn {address, value} ->
-        :ets.insert(cache, {address, stat, time}, value)
+        :ets.insert(cache, {{address, stat, time}, value})
       end)
     end)
   end

--- a/lib/blockchain_api/query/hotspot.ex
+++ b/lib/blockchain_api/query/hotspot.ex
@@ -3,7 +3,6 @@ defmodule BlockchainAPI.Query.Hotspot do
   import Ecto.Query, warn: false
 
   alias BlockchainAPI.{
-    Query.HotspotStats,
     Repo,
     Schema.Hotspot,
     Util
@@ -47,21 +46,6 @@ defmodule BlockchainAPI.Query.Hotspot do
     |> where([h], is_nil(h.location))
     |> order_by([h], desc: h.id)
     |> Repo.all()
-  end
-
-  def stats(address) do
-    address = Util.string_to_bin(address)
-
-    %{
-      challenges_completed: HotspotStats.challenges_completed_map(),
-      consensus_groups: HotspotStats.consensus_groups_map(),
-      hlm_earned: HotspotStats.hlm_earned_map(),
-      earning_percentile: HotspotStats.earning_percentile_map(),
-      challenges_witnessed: HotspotStats.challenges_witnessed_map(),
-      witnessed_percentile: HotspotStats.witnessed_percentile_map(),
-      furthest_witness: HotspotStats.furthest_witness(),
-      furthest_witness_percentile: HotspotStats.furthest_witness_percentile()
-    }
   end
 
   # Search hotspots with fuzzy str match with Levenshtein distance

--- a/lib/blockchain_api/query/hotspot.ex
+++ b/lib/blockchain_api/query/hotspot.ex
@@ -53,14 +53,14 @@ defmodule BlockchainAPI.Query.Hotspot do
     address = Util.string_to_bin(address)
 
     %{
-      challenges_completed: HotspotStats.challenges_completed_map(address),
-      consensus_groups: HotspotStats.consensus_groups_map(address),
-      hlm_earned: HotspotStats.hlm_earned_map(address),
-      earning_percentile: HotspotStats.earning_percentile_map(address),
-      challenges_witnessed: HotspotStats.challenges_witnessed_map(address),
-      witnessed_percentile: HotspotStats.witnessed_percentile_map(address),
-      furthest_witness: HotspotStats.furthest_witness(address),
-      furthest_witness_percentile: HotspotStats.furthest_witness_percentile(address)
+      challenges_completed: HotspotStats.challenges_completed_map(),
+      consensus_groups: HotspotStats.consensus_groups_map(),
+      hlm_earned: HotspotStats.hlm_earned_map(),
+      earning_percentile: HotspotStats.earning_percentile_map(),
+      challenges_witnessed: HotspotStats.challenges_witnessed_map(),
+      witnessed_percentile: HotspotStats.witnessed_percentile_map(),
+      furthest_witness: HotspotStats.furthest_witness(),
+      furthest_witness_percentile: HotspotStats.furthest_witness_percentile()
     }
   end
 

--- a/lib/blockchain_api/query/hotspot_stats.ex
+++ b/lib/blockchain_api/query/hotspot_stats.ex
@@ -14,74 +14,73 @@ defmodule BlockchainAPI.Query.HotspotStats do
     Util
   }
 
-  def challenges_completed_map(address) do
+  def challenges_completed do
     %{
-      "24h" => challenges_completed(address, Util.shifted_unix_time(hours: -24)),
-      "7d" => challenges_completed(address, Util.shifted_unix_time(days: -7)),
-      "30d" => challenges_completed(address, Util.shifted_unix_time(days: -30)),
-      "all_time" => challenges_completed(address),
+      "24h" => challenges_completed(Util.shifted_unix_time(hours: -24)),
+      "7d" => challenges_completed(Util.shifted_unix_time(days: -7)),
+      "30d" => challenges_completed(Util.shifted_unix_time(days: -30)),
+      "all_time" => challenges_completed(),
     }
   end
 
-  def consensus_groups_map(address) do
+  def consensus_groups do
     %{
-      "24h" => consensus_groups(address, Util.shifted_unix_time(hours: -24)),
-      "7d" => consensus_groups(address, Util.shifted_unix_time(days: -7)),
-      "30d" => consensus_groups(address, Util.shifted_unix_time(days: -30)),
-      "all_time" => consensus_groups(address),
+      "24h" => consensus_groups(Util.shifted_unix_time(hours: -24)),
+      "7d" => consensus_groups(Util.shifted_unix_time(days: -7)),
+      "30d" => consensus_groups(Util.shifted_unix_time(days: -30)),
+      "all_time" => consensus_groups(),
     }
   end
 
-  def hlm_earned_map(address) do
+  def hlm_earned do
     %{
-      "24h" => hlm_earned(address, Util.shifted_unix_time(hours: -24)),
-      "7d" => hlm_earned(address, Util.shifted_unix_time(days: -7)),
-      "30d" => hlm_earned(address, Util.shifted_unix_time(days: -30)),
-      "all_time" => hlm_earned(address),
+      "24h" => hlm_earned(Util.shifted_unix_time(hours: -24)),
+      "7d" => hlm_earned(Util.shifted_unix_time(days: -7)),
+      "30d" => hlm_earned(Util.shifted_unix_time(days: -30)),
+      "all_time" => hlm_earned(),
     }
   end
 
-  def earning_percentile_map(address) do
+  def earning_percentile do
     %{
-      "24h" => earning_percentile(address, Util.shifted_unix_time(hours: -24)),
-      "7d" => earning_percentile(address, Util.shifted_unix_time(days: -7)),
-      "30d" => earning_percentile(address, Util.shifted_unix_time(days: -30)),
-      "all_time" => earning_percentile(address),
+      "24h" => earning_percentile(Util.shifted_unix_time(hours: -24)),
+      "7d" => earning_percentile(Util.shifted_unix_time(days: -7)),
+      "30d" => earning_percentile(Util.shifted_unix_time(days: -30)),
+      "all_time" => earning_percentile(),
     }
   end
 
-  def challenges_witnessed_map(address) do
+  def challenges_witnessed do
     %{
-      "24h" => challenges_witnessed(address, Util.shifted_unix_time(hours: -24)),
-      "7d" => challenges_witnessed(address, Util.shifted_unix_time(days: -7)),
-      "30d" => challenges_witnessed(address, Util.shifted_unix_time(days: -30)),
-      "all_time" => challenges_witnessed(address),
+      "24h" => challenges_witnessed(Util.shifted_unix_time(hours: -24)),
+      "7d" => challenges_witnessed(Util.shifted_unix_time(days: -7)),
+      "30d" => challenges_witnessed(Util.shifted_unix_time(days: -30)),
+      "all_time" => challenges_witnessed(),
     }
   end
 
-  def witnessed_percentile_map(address) do
+  def witnessed_percentile do
     %{
-      "24h" => witnessed_percentile(address, Util.shifted_unix_time(hours: -24)),
-      "7d" => witnessed_percentile(address, Util.shifted_unix_time(days: -7)),
-      "30d" => witnessed_percentile(address, Util.shifted_unix_time(days: -30)),
-      "all_time" => witnessed_percentile(address),
+      "24h" => witnessed_percentile(Util.shifted_unix_time(hours: -24)),
+      "7d" => witnessed_percentile(Util.shifted_unix_time(days: -7)),
+      "30d" => witnessed_percentile(Util.shifted_unix_time(days: -30)),
+      "all_time" => witnessed_percentile(),
     }
   end
 
-  defp challenges_completed(address, start_time \\ 0) do
+  defp challenges_completed(start_time \\ 0) do
     from(
       pr in POCReceipt,
-      where: pr.gateway == ^address,
       where: pr.timestamp >= ^start_time,
-      select: count(pr.id)
+      group_by: pr.gateway,
+      select: {pr.gateway, count(pr.id)}
     )
-    |> Repo.one()
+    |> Repo.stream()
   end
 
-  defp consensus_groups(address, start_time \\ 0) do
+  defp consensus_groups(start_time \\ 0) do
     from(
       cm in ConsensusMember,
-      where: cm.address == ^address,
       inner_join: et in ElectionTransaction,
       on: cm.election_transactions_id == et.id,
       inner_join: t in Transaction,
@@ -89,24 +88,24 @@ defmodule BlockchainAPI.Query.HotspotStats do
       inner_join: b in Block,
       on: t.block_height == b.height,
       where: b.time >= ^start_time,
-      select: count(cm.id)
+      group_by: cm.address,
+      select: {cm.address, count(cm.id)}
     )
-    |> Repo.one()
+    |> Repo.stream()
   end
 
-  defp hlm_earned(address, start_time \\ 0) do
+  defp hlm_earned(start_time \\ 0) do
     from(
       rt in RewardTxn,
-      where: rt.gateway == ^address,
       inner_join: t in Transaction,
       on: rt.rewards_hash == t.hash,
       inner_join: b in Block,
       on: t.block_height == b.height,
       where: b.time >= ^start_time,
-      select: sum(rt.amount)
+      group_by: rt.gateway,
+      select: {rt.gateway, sum(rt.amount)}
     )
-    |> Repo.one()
-    |> Kernel.||(0)
+    |> Repo.stream()
   end
 
   defp earning_percentile(address, start_time \\ 0) do
@@ -122,19 +121,19 @@ defmodule BlockchainAPI.Query.HotspotStats do
         order_by: [desc: sum(rt.amount)],
         select: rt.gateway
       )
-      |> Repo.all()
+      |> Repo.stream()
 
     get_percentile(ranking, address)
   end
 
-  defp challenges_witnessed(address, start_time \\ 0) do
+  defp challenges_witnessed(start_time \\ 0) do
     from(
       pw in POCWitness,
-      where: pw.gateway == ^address,
       where: pw.timestamp >= ^start_time,
-      select: count(pw.id)
+      group_by: pw.gateway,
+      select: {pw.gateway, count(pw.id)}
     )
-    |> Repo.one()
+    |> Repo.stream()
   end
 
   defp witnessed_percentile(address, start_time \\ 0) do
@@ -146,18 +145,18 @@ defmodule BlockchainAPI.Query.HotspotStats do
         order_by: [desc: count(pw.id)],
         select: pw.gateway
       )
-      |> Repo.all()
+      |> Repo.stream()
 
     get_percentile(ranking, address)
   end
 
-  def furthest_witness(address) do
+  def furthest_witness do
     from(
       pw in POCWitness,
-      where: pw.gateway == ^address,
-      select: max(pw.distance)
+      group_by: pw.gateway,
+      select: {pw.gateway, max(pw.distance)}
     )
-    |> Repo.one()
+    |> Repo.stream()
   end
 
   def furthest_witness_percentile(address) do
@@ -168,7 +167,7 @@ defmodule BlockchainAPI.Query.HotspotStats do
         order_by: [desc: max(pw.distance)],
         select: pw.gateway
       )
-      |> Repo.all()
+      |> Repo.stream()
 
     get_percentile(ranking, address)
   end

--- a/lib/blockchain_api/watcher.ex
+++ b/lib/blockchain_api/watcher.ex
@@ -1,6 +1,6 @@
 defmodule BlockchainAPI.Watcher do
   use GenServer
-  alias BlockchainAPI.{Query, Committer}
+  alias BlockchainAPI.{Cache, Committer, Query}
 
   @me __MODULE__
   require Logger
@@ -107,7 +107,9 @@ defmodule BlockchainAPI.Watcher do
             |> Enum.map(fn h ->
               {:ok, b} = :blockchain.get_block(h, chain)
               h = :blockchain_block.height(b)
-              Committer.commit(b, ledger, h, sync_flag, env)
+              with {:ok, _} <- Committer.commit(b, ledger, h, sync_flag, env) do
+                Cache.HotspotStats.update_cache()
+              end
             end)
 
           false ->

--- a/lib/blockchain_api_web/controllers/hotspot_controller.ex
+++ b/lib/blockchain_api_web/controllers/hotspot_controller.ex
@@ -64,7 +64,7 @@ defmodule BlockchainAPIWeb.HotspotController do
   end
 
   def stats(conn, %{"hotspot_address" => address}) do
-    stats = Query.Hotspot.stats(address)
+    stats = Query.HotspotStats.individual_stats(address)
 
     render(conn, "stats.json", stats: stats)
   end

--- a/priv/repo/migrations/20191002181828_add_index_to_reward_txns.exs
+++ b/priv/repo/migrations/20191002181828_add_index_to_reward_txns.exs
@@ -1,0 +1,7 @@
+defmodule BlockchainAPI.Repo.Migrations.AddIndexToRewardTxns do
+  use Ecto.Migration
+
+  def change do
+    create_if_not_exists(index("reward_txns", ["gateway"], name: "reward_txns_gateway"))
+  end
+end


### PR DESCRIPTION
This is an update to #186 to cache the hotspot stats in an ets table. The cache would be populated when the application is started and updated every time the committer commits a new block.