### PR TITLE
Use worker chain to workaround ledger corruption

### DIFF
--- a/lib/blockchain_api_web/controllers/account_controller.ex
+++ b/lib/blockchain_api_web/controllers/account_controller.ex
@@ -39,7 +39,7 @@ defmodule BlockchainAPIWeb.AccountController do
       # This account does not exist in the database, hence we return some default values
       _error in Ecto.NoResultsError ->
         {:ok, fee} =
-          Watcher.chain()
+          :blockchain_worker.blockchain()
           |> :blockchain.ledger()
           |> :blockchain_ledger_v1.transaction_fee()
 


### PR DESCRIPTION
Doing a ledger reset would make the watcher processes chain turn to a bad state I believe. This queries the `blockchain_worker` for the chain directly. I suppose we should've been using that to begin with.