### PR TITLE
increase sync block rounding by 100x

### DIFF
--- a/lib/blockchain_api/query/hotspot_status.ex
+++ b/lib/blockchain_api/query/hotspot_status.ex
@@ -55,7 +55,7 @@ defmodule BlockchainAPI.Query.HotspotStatus do
 
         case :libp2p_peer.signed_metadata_get(peer, <<"height">>, :undefined) do
           height when is_integer(height) and height > 0 ->
-            case abs(api_height - height) <= 5 do
+            case abs(api_height - height) <= 500 do
               true ->
                 1.0
 


### PR DESCRIPTION
addresses: https://app.clubhouse.io/hlm/story/5274/be-a-little-less-precise-on-sync-status

we want to eliminate the framtic support messages when syncing percent drops to 99.99%. currently we have a grace period of 5 blocks to consider it 100% synced. 100 blocks is ~0.1%. So 500 blocks will consider anything above ~99.5% fully synced.