### PR TITLE
Bump challenge status query to 65 blocks

### DIFF
--- a/lib/blockchain_api/query/account_transaction.ex
+++ b/lib/blockchain_api/query/account_transaction.ex
@@ -164,7 +164,7 @@ defmodule BlockchainAPI.Query.AccountTransaction do
           location_height: lsq.location_height,
           status:
             fragment(
-              "CASE WHEN ? - ? < 35 THEN 'online' ELSE CASE WHEN ? - ? < 35 THEN 'online' ELSE 'offline' END END",
+              "CASE WHEN ? - ? < 65 THEN 'online' ELSE CASE WHEN ? - ? < 65 THEN 'online' ELSE 'offline' END END",
               ^current_height,
               s.challenge_height,
               ^current_height,


### PR DESCRIPTION
Note: Ecto doesn't allow parameterization of first argument in a fragment query, sucks but true.