### PR TITLE
Set challenge status timeout to 130 blocks

### DIFF
--- a/lib/blockchain_api/query/account_transaction.ex
+++ b/lib/blockchain_api/query/account_transaction.ex
@@ -164,7 +164,7 @@ defmodule BlockchainAPI.Query.AccountTransaction do
           location_height: lsq.location_height,
           status:
             fragment(
-              "CASE WHEN ? - ? < 65 THEN 'online' ELSE CASE WHEN ? - ? < 65 THEN 'online' ELSE 'offline' END END",
+              "CASE WHEN ? - ? < 130 THEN 'online' ELSE CASE WHEN ? - ? < 130 THEN 'online' ELSE 'offline' END END",
               ^current_height,
               s.challenge_height,
               ^current_height,


### PR DESCRIPTION
We never bothered to update the poc request timeout blocks after we made the poc challenge interval to 60 blocks from 30. This fixes that.